### PR TITLE
Fix hash params not being persisted when updating the query string

### DIFF
--- a/packages/raydiant-simulator/src/Simulator.js
+++ b/packages/raydiant-simulator/src/Simulator.js
@@ -84,7 +84,7 @@ class RaydiantAppSimulator extends Component {
     }
 
     const qs = querystring.stringify(queryParams);
-    window.history.replaceState(null, '', `?${qs}`);
+    window.history.replaceState(null, '', `?${qs}${window.location.hash}`);
   }
 
   hasStateChanged(key) {


### PR DESCRIPTION
https://trello.com/c/RazsGPF5/1253-bug-raydiantkit-oauth-not-persisting-access-token