### PR TITLE
[b] East - Fix VideoType accept types to work with FireFox

### DIFF
--- a/packages/raydiant-kit/src/prop-types/VideoType.ts
+++ b/packages/raydiant-kit/src/prop-types/VideoType.ts
@@ -5,8 +5,8 @@ export const videoContentTypes = [
   'video/mp4',
   'video/mpeg',
   'video/quicktime',
-  'video/m4v',
-  'video/webm',
+  'video/x-m4v',
+  '.webm',
 ];
 export default class VideoType extends FileType {
   constructor(label: string) {


### PR DESCRIPTION
## Description
- Trello card: [P1 Bug: "Upload Video" doesn't work in Firefox [ACCESS APPROVED]](https://trello.com/c/z9toLnoZ/1495-p1-bug-upload-video-doesnt-work-in-firefox)
- Bump version from `4.1.0` to `4.1.1`

## Notes
- Uploading works fine in Firefox
- Firefox file input hasn't supported `video/m4v` => `video/x-m4v` works on chrome, firefox and safari
- Firefox file input hasn't supported `video/webm` => `.webm` works on chrome, firefox and safari (safari video tag does not support .webm https://www.w3schools.com/tags/tag_video.asp)
- Note `video/*` works fine on chrome and firefox but not work on safari