### PR TITLE
Fix setting nested appVar props via hash params

### DIFF
--- a/packages/raydiant-simulator/src/Simulator.js
+++ b/packages/raydiant-simulator/src/Simulator.js
@@ -16,7 +16,6 @@ import mergeDefaultAppVars from './mergeDefaultAppVars';
 
 const PRESENTATION_MIN_DURATION = 5;
 const EMPTY_PRESENTATION = { name: 'New Presentation', application_vars: {} };
-const EMPTY_APP_VERSION = { icon_url: '', presentation_properties: [] };
 
 class RaydiantAppSimulator extends Component {
   initialState = {
@@ -314,8 +313,8 @@ class RaydiantAppSimulator extends Component {
     presentation = presentation || EMPTY_PRESENTATION;
 
     if (!appVersion) {
-      // rendering the preview also indirectly updates this.state.appVersion
-      // using the values defined in raydiant.config.js
+      // rendering the preview also indirectly updates
+      // this.state.appVersion using the values defined in raydiant.config.js
       return this.renderPreview(presentation, [], previewMode);
     }
 

--- a/packages/raydiant-simulator/src/Simulator.js
+++ b/packages/raydiant-simulator/src/Simulator.js
@@ -312,7 +312,12 @@ class RaydiantAppSimulator extends Component {
     let { presentation, appVersion, simulatorOptions } = this.state;
 
     presentation = presentation || EMPTY_PRESENTATION;
-    appVersion = appVersion || EMPTY_APP_VERSION;
+
+    if (!appVersion) {
+      // rendering the preview also indirectly updates this.state.appVersion
+      // using the values defined in raydiant.config.js
+      return this.renderPreview(presentation, [], previewMode);
+    }
 
     presentation = {
       ...mergeDefaultAppVars(


### PR DESCRIPTION
Fixes a bug where app vars were not being updated correctly via hash params. E.g: `https://dash.staging.raydiant.com/presentations/...#applicationVariables.accessToken=<accessToken>`

Before this change, `this.state.appVersion` defaulted to:
```const EMPTY_APP_VERSION = { icon_url: '', presentation_properties: [] }```
on page load. 
This causes issues when setting properties not present in `EMPTY_APP_VERSION`.

The fix is to ensure the simulator always has access to the full appVersion that's generated from the`raydiant.config.js.` file.