### PR TITLE
[b] East - Fix bug description is not showing in the simulator preview

### DIFF
--- a/packages/raydiant-simulator/src/Simulator.js
+++ b/packages/raydiant-simulator/src/Simulator.js
@@ -185,7 +185,10 @@ class RaydiantAppSimulator extends Component {
       appVersion: {
         ...appVersion,
         presentation_properties: properties,
-        strings,
+        strings: {
+          ...appVersion.strings,
+          ...strings,
+        },
       },
     });
   };


### PR DESCRIPTION
## Description
- Fix bug description is not showing in the preview
  - The issue caused by 5f24a00cc8b1c75b9d2415bcc2c569a56c8f69ff
  - Reason: since the extracted `strings` value depends on the `propTypes` (reflex in file `raydiant-kit/packages/raydiant-kit/lib/prop-types/extractProperties.js`). For any string that does not have the key name in `propTypes`, the string value is not extracted.