### PR TITLE
Expose device name to apps

### DIFF
--- a/packages/raydiant-kit/src/withRaydiantApp.test.tsx
+++ b/packages/raydiant-kit/src/withRaydiantApp.test.tsx
@@ -39,6 +39,10 @@ const createProps = () => ({
   },
   isDashboard: false,
   isThumbnail: false,
+  device: {
+    id: 'my-device',
+    name: 'My Device',
+  },
 });
 
 const App: React.SFC<any> = () => <div />;
@@ -52,7 +56,7 @@ test('Should render app', () => {
   const app = wrapper.find(App);
   expect(app.length).toEqual(1);
   const appProps = app.props();
-  expect(Object.keys(appProps).length).toEqual(12);
+  expect(Object.keys(appProps).length).toEqual(13);
   expect(appProps.presentation.name).toEqual(props.presentation.name);
   expect(appProps.presentation.values).toEqual(
     props.presentation.application_vars,
@@ -94,6 +98,8 @@ test('Should render app', () => {
   expect(appProps.isDashboard).toEqual(true);
   expect(appProps.isThumbnail).toEqual(true);
   expect(appProps.miraEvents).toBeInstanceOf(EventEmitter);
+  expect(appProps.device.id).toEqual('my-device');
+  expect(appProps.device.name).toEqual('My Device');
 });
 
 test('Should render error', () => {

--- a/packages/raydiant-kit/src/withRaydiantApp.tsx
+++ b/packages/raydiant-kit/src/withRaydiantApp.tsx
@@ -21,6 +21,10 @@ interface RaydiantAppProps {
     application_deployment_id: string;
     application_name: string;
   };
+  device: {
+    id: string;
+    name: string;
+  };
   miraEvents: EventEmitter;
   strings: { [key: string]: string };
   isDashboard: boolean;
@@ -136,7 +140,6 @@ export default function withRaydiantApp(
     };
 
     render() {
-      const { presentation } = this.props;
       const { error, isPlaying, playCount } = this.state;
 
       if (error) {
@@ -149,6 +152,8 @@ export default function withRaydiantApp(
       }
 
       const {
+        presentation,
+        device,
         miraEvents,
         miraFileResource,
         miraRequestResource,
@@ -162,6 +167,7 @@ export default function withRaydiantApp(
         <App
           {...legacyApplicationVars}
           presentation={mapPresentationToProps(presentation)}
+          device={device}
           isPlaying={isPlaying}
           playCount={playCount}
           onReady={this.handlePresentationReady}

--- a/packages/raydiant-simulator/src/AppLoader.js
+++ b/packages/raydiant-simulator/src/AppLoader.js
@@ -15,6 +15,10 @@ class AppLoader extends Component {
       application_id: PropTypes.string,
       application_name: PropTypes.string,
     }).isRequired,
+    device: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
     theme: PropTypes.object,
     selectedPaths: PropTypes.arrayOf(PropTypes.array),
     onLoad: PropTypes.func.isRequired,
@@ -60,7 +64,7 @@ class AppLoader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { presentation, theme, auth, selectedPaths } = this.props;
+    const { presentation, device, theme, auth, selectedPaths } = this.props;
     if (!this.checkPreviewErrors()) {
       // Send app vars if:
       //  - There are no errors.
@@ -69,10 +73,12 @@ class AppLoader extends Component {
       if (
         !this.hasSentInitialProps ||
         !deepEqual(presentation, prevProps.presentation) ||
-        !deepEqual(auth, prevProps.auth)
+        !deepEqual(auth, prevProps.auth) ||
+        !deepEqual(device, prevProps.device)
       ) {
         this.messenger.send('props', {
           presentation: { ...presentation, theme },
+          device,
           auth,
           selectedPaths,
         });

--- a/packages/raydiant-simulator/src/AppPreview.js
+++ b/packages/raydiant-simulator/src/AppPreview.js
@@ -19,6 +19,7 @@ class AppPreview extends Component {
   };
 
   state = {
+    device: null,
     presentation: null,
     auth: null,
     selectedPaths: [],
@@ -64,9 +65,9 @@ class AppPreview extends Component {
     if (type === 'play') {
       this.miraEvents.emit('play');
     } else if (type === 'props') {
-      const { presentation, auth, selectedPaths } = payload;
+      const { presentation, device, auth, selectedPaths } = payload;
       this.setState(
-        { presentation, auth, selectedPaths },
+        { presentation, device, auth, selectedPaths },
         this.runGetProperties,
       );
     } else if (type === 'selectedPaths') {
@@ -109,7 +110,7 @@ class AppPreview extends Component {
 
   render() {
     const { allowedRequestDomains, children, simulatorOptions } = this.props;
-    const { presentation, auth, selectedPaths } = this.state;
+    const { presentation, device, auth, selectedPaths } = this.state;
     // Don't render the app if we haven't received the presentation object yet.
     if (!presentation) return null;
     // Spreading app props will be deprecated. New apps should use the presentation
@@ -119,6 +120,7 @@ class AppPreview extends Component {
     const props = {
       ...legacyApplicationVars,
       presentation,
+      device,
       auth,
       selectedPaths,
       miraEvents: this.miraEvents,

--- a/packages/raydiant-simulator/src/Simulator.js
+++ b/packages/raydiant-simulator/src/Simulator.js
@@ -285,6 +285,7 @@ class RaydiantAppSimulator extends Component {
     const appLoader = (
       <AppLoader
         presentation={presentation}
+        device={simulatorOptions.device}
         theme={theme}
         selectedPaths={selectedPaths}
         previewErrors={errors}


### PR DESCRIPTION
https://trello.com/c/1lIRL2vr

```js
// raydiant.config.js
export default {
   ...,
   simulator: {
     device: {
       id: 'my-device',
       name: 'My Device'
     }
   } 
}

// App.js
render() {
  const { device } = this.props;
  return (
     // Don't assume that the device object exists. When previewing the app in the
     // Dashboard this.props.device will not exist.
     device 
        ? `App is running on device ${device.name}` 
        : 'App is running in the Dashboard preview`
  )
}

```