### PR TITLE
Support async generator functions

### DIFF
--- a/examples/menu/package.json
+++ b/examples/menu/package.json
@@ -1,12 +1,12 @@
 {
   "name": "menu",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "dependencies": {
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
     "raydiant-kit": "^4.5.1",
-    "raydiant-scripts": "^4.5.1",
+    "raydiant-scripts": "^4.5.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/examples/video-player/package.json
+++ b/examples/video-player/package.json
@@ -1,12 +1,12 @@
 {
   "name": "video-player",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "dependencies": {
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
     "raydiant-kit": "^4.5.1",
-    "raydiant-scripts": "^4.5.1",
+    "raydiant-scripts": "^4.5.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -1,12 +1,12 @@
 {
   "name": "weather",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "dependencies": {
     "netlify-cli": "^1.2.2",
     "prop-types": "^15.6.1",
     "raydiant-kit": "^4.5.1",
-    "raydiant-scripts": "^4.5.1",
+    "raydiant-scripts": "^4.5.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "2.9.0",
   "packages": ["packages/*"],
-  "version": "4.5.1",
+  "version": "4.5.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "changelog": {

--- a/packages/raydiant-scripts/config/webpack.common.js
+++ b/packages/raydiant-scripts/config/webpack.common.js
@@ -79,6 +79,13 @@ module.exports = {
               // that come with their own babel plugins. See NextJS for how we might to this.
               babelrc: false,
               presets: [require.resolve('babel-preset-react-app')],
+              plugins: [
+                [
+                  require.resolve(
+                    '@babel/plugin-proposal-async-generator-functions',
+                  ),
+                ],
+              ],
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.

--- a/packages/raydiant-scripts/package.json
+++ b/packages/raydiant-scripts/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@babel/core": "7.0.0-beta.42",
+    "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.42",
     "@babel/register": "^7.0.0-beta.42",
     "@babel/runtime": "7.0.0-beta.42",
     "autoprefixer": "7.2.5",

--- a/packages/raydiant-scripts/package.json
+++ b/packages/raydiant-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raydiant-scripts",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "repository": "git@github.com:mirainc/raydiant-kit.git",
   "bin": {
     "raydiant-scripts": "./bin/raydiant-scripts.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,13 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.42.tgz#f2b0a3be684018b55fc308eb5408326f78479085"
+  integrity sha512-2lmcB7mHRSXZjDV9fdnWGRco+5fbI0PdUtsL7mNA2GtJs0GPoKdV3sCx0N4cpzG2YRR4dNCiB2riYIrzWjmQ1Q==
+  dependencies:
+    "@babel/types" "7.0.0-beta.42"
+
 "@babel/helper-annotate-as-pure@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.44.tgz#8ecf33cc5235295afcc7f160a63cab17ce7776f4"
@@ -190,6 +197,11 @@
   dependencies:
     "@babel/types" "7.0.0-beta.44"
 
+"@babel/helper-plugin-utils@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.42.tgz#9aa8b3e5dc72abea6b4f686712a7363cb29ea057"
+  integrity sha512-hZLw8Iz9/YOxI9mgWyPOP1S84OcdQo1WFkZrS1sSf45g16sEb4dVslds2uvZgmx9BiG94PoWyABGf48Py6D6CA==
+
 "@babel/helper-plugin-utils@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz#9f590bc3ae6daa8a10b853233baa3e25d263751d"
@@ -199,6 +211,17 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.44.tgz#f5b6828c1e40f0b74ab6ed90abdd52be0c38a74e"
   dependencies:
     lodash "^4.2.0"
+
+"@babel/helper-remap-async-to-generator@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.42.tgz#c27dd7789f3a9973493a67a7914ac9253e879071"
+  integrity sha512-At+ipbHRYoN0AaafqPvTPqyVYi+beantKZ2orCYSb/AzP2+JywaWlOPH0wyXLOGzjkJX548Is4cV2wGbEG7++Q==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.42"
+    "@babel/helper-wrap-function" "7.0.0-beta.42"
+    "@babel/template" "7.0.0-beta.42"
+    "@babel/traverse" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.42"
 
 "@babel/helper-remap-async-to-generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -238,6 +261,16 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
   dependencies:
     "@babel/types" "7.0.0-beta.44"
+
+"@babel/helper-wrap-function@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.42.tgz#5ffc6576902aa2a10fe6666e063bd45029c36db3"
+  integrity sha512-jpZDbZROEw2HfmlImLXDB7BFoyo6M/Wn8jOOc1+JfCpg2uaZ+n6Q0C3sA6mCN6o7ZgpJkgT7IHQwdB3RMV6KLA==
+  dependencies:
+    "@babel/helper-function-name" "7.0.0-beta.42"
+    "@babel/template" "7.0.0-beta.42"
+    "@babel/traverse" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.42"
 
 "@babel/helper-wrap-function@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -280,6 +313,15 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.42.tgz#81465d19b6f5559092d9be4d11d6351131d08696"
+  integrity sha512-fPPsSCajWzefDSb49JEeZfd/UeMK3xEQSRAz/H3BZ1uaRatwNNZoOJq4/WRH/xDeISmYUdkLRtqs39VPWLKYVg==
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.42"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.42"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.42"
+
 "@babel/plugin-proposal-async-generator-functions@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.44.tgz#b08d90cd0f6a82e11cb5ae64eee4fba7d0d7999e"
@@ -317,6 +359,13 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.44"
     "@babel/helper-regex" "7.0.0-beta.44"
     regexpu-core "^4.1.3"
+
+"@babel/plugin-syntax-async-generators@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.42.tgz#deccff2f01c2ed280493b0ba256b14df232ca299"
+  integrity sha512-k6oVMsmY/mcp+rPRcK4dJL/J1ahtIRucXtNHNvAVRV9WFc7G3r1rrb1GlM4iNHareXBNdRlf7mkxyVaVpyJ3TQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.42"
 
 "@babel/plugin-syntax-async-generators@7.0.0-beta.44":
   version "7.0.0-beta.44"


### PR DESCRIPTION
The following PR enables app developers to use async generator functions from their application code.

The virtual-rooms app requires async generator functions to listen to events from the hardware endpoint.
See [here](https://github.com/mirainc/photon/blob/resin/src/clients/connectivityService.js#L87-L98) for an example of the `events` function for the connectivityService