### PR TITLE
[b] East - Fix drag-n-drop webm videos

### DIFF
--- a/packages/raydiant-kit/src/prop-types/VideoType.ts
+++ b/packages/raydiant-kit/src/prop-types/VideoType.ts
@@ -6,7 +6,7 @@ export const videoContentTypes = [
   'video/mpeg',
   'video/quicktime',
   'video/x-m4v',
-  '.webm',
+  'video/webm',
 ];
 export default class VideoType extends FileType {
   constructor(label: string) {


### PR DESCRIPTION
## Description
- [P2 Bug: Unable to upload webm videos](https://trello.com/c/1d8L450w/2449-p2-bug-unable-to-upload-webm-videos)
- We can drag-n-drop WebM videos to upload them because we set the wrong MIME type.