### PR TITLE
[f] East - Add rightLabel, searchable, searchable, sorting props into SelectionType

### DIFF
--- a/packages/raydiant-kit/src/prop-types/SelectionType.ts
+++ b/packages/raydiant-kit/src/prop-types/SelectionType.ts
@@ -3,14 +3,29 @@ import BaseType, { PropType } from './BaseType';
 interface Option {
   label: string;
   value: string;
+  rightLabel?: string;
   thumbnailUrl?: string;
+}
+
+type SortKey = 'default' | 'label' | 'rightLabel';
+
+interface SortConf {
+  name: string,
+  isNumeric?: boolean,
+}
+
+type Sorting = {
+  [K in SortKey]?: SortConf;
 }
 
 export interface SelectionPropType extends PropType {
   default: string;
   multiple: boolean;
+  searchable: boolean;
+  selectable: boolean;
   options: Option[];
   optionsUrl: string;
+  sorting?: Sorting;
 }
 
 export default class SelectionType extends BaseType<SelectionPropType> {
@@ -29,6 +44,16 @@ export default class SelectionType extends BaseType<SelectionPropType> {
     return this;
   }
 
+  searchable(value = true) {
+    this.propType.searchable = value;
+    return this;
+  }
+
+  selectable(value = true) {
+    this.propType.selectable = value;
+    return this;
+  }
+
   option(value: string, label: string, thumbnailUrl?: string) {
     if (!label) label = value;
     this.propType.options.push({ label, value, thumbnailUrl });
@@ -37,6 +62,14 @@ export default class SelectionType extends BaseType<SelectionPropType> {
 
   optionsUrl(url: string) {
     this.propType.optionsUrl = url;
+    return this;
+  }
+
+  sortBy(key: SortKey, name: string, isNumeric = false) {
+    this.propType.sorting = {
+      ...this.propType.sorting,
+      [key]: {name, isNumeric},
+    };
     return this;
   }
 }

--- a/packages/raydiant-kit/src/prop-types/SelectionType.ts
+++ b/packages/raydiant-kit/src/prop-types/SelectionType.ts
@@ -7,15 +7,11 @@ interface Option {
   thumbnailUrl?: string;
 }
 
-type SortKey = 'default' | 'label' | 'rightLabel';
-
-interface SortConf {
-  name: string,
-  isNumeric?: boolean,
-}
-
-type Sorting = {
-  [K in SortKey]?: SortConf;
+interface SortOption {
+  label: string,
+  by: 'default' | 'label' | 'rightLabel',
+  type?: 'string' | 'number' | 'boolean',
+  defaultDirection?: 'asc' | 'desc',
 }
 
 export interface SelectionPropType extends PropType {
@@ -23,9 +19,9 @@ export interface SelectionPropType extends PropType {
   multiple: boolean;
   searchable: boolean;
   selectable: boolean;
+  sortable?: SortOption[];
   options: Option[];
   optionsUrl: string;
-  sorting?: Sorting;
 }
 
 export default class SelectionType extends BaseType<SelectionPropType> {
@@ -54,6 +50,11 @@ export default class SelectionType extends BaseType<SelectionPropType> {
     return this;
   }
 
+  sortable(sortOptions: SortOption[]) {
+    this.propType.sortable = sortOptions;
+    return this;
+  }
+
   option(value: string, label: string, thumbnailUrl?: string) {
     if (!label) label = value;
     this.propType.options.push({ label, value, thumbnailUrl });
@@ -62,14 +63,6 @@ export default class SelectionType extends BaseType<SelectionPropType> {
 
   optionsUrl(url: string) {
     this.propType.optionsUrl = url;
-    return this;
-  }
-
-  sortBy(key: SortKey, name: string, isNumeric = false) {
-    this.propType.sorting = {
-      ...this.propType.sorting,
-      [key]: {name, isNumeric},
-    };
     return this;
   }
 }

--- a/packages/raydiant-kit/src/prop-types/extractProperties.test.ts
+++ b/packages/raydiant-kit/src/prop-types/extractProperties.test.ts
@@ -316,6 +316,14 @@ test('Should extract properties from selection', () => {
       .helperLink('http://helper.link'),
     multiple: selection('Selection').multiple(),
     optionsUrl: selection('Selection').optionsUrl('https://options.url'),
+    searchable: selection('Selection').multiple().searchable(),
+    selectable: selection('Selection').multiple().selectable(),
+    sorting: selection('Selection')
+      .multiple()
+      .searchable()
+      .sortBy('default', 'Original')
+      .sortBy('label', 'Name')
+      .sortBy('rightLabel', 'Price', true),
   };
 
   const { properties, strings } = extractProperties(propTypes);
@@ -329,6 +337,9 @@ test('Should extract properties from selection', () => {
     helper_helperText: 'helperText',
     multiple: 'Selection',
     optionsUrl: 'Selection',
+    searchable: 'Selection',
+    selectable: 'Selection',
+    sorting: 'Selection',
   });
   expect(properties).toEqual([
     {
@@ -380,6 +391,38 @@ test('Should extract properties from selection', () => {
       constraints: {},
       options: [],
       options_url: 'https://options.url',
+    },
+    {
+      type: 'selection',
+      name: 'searchable',
+      multiple: true,
+      searchable: true,
+      optional: true,
+      constraints: {},
+      options: [],
+    },
+    {
+      type: 'selection',
+      name: 'selectable',
+      multiple: true,
+      selectable: true,
+      optional: true,
+      constraints: {},
+      options: [],
+    },
+    {
+      type: 'selection',
+      name: 'sorting',
+      multiple: true,
+      searchable: true,
+      optional: true,
+      constraints: {},
+      options: [],
+      sorting: {
+        default: { name: 'Original', isNumeric: false },
+        label: { name: 'Name', isNumeric: false },
+        rightLabel: { name: 'Price', isNumeric: true },
+      },
     },
   ]);
 });

--- a/packages/raydiant-kit/src/prop-types/extractProperties.test.ts
+++ b/packages/raydiant-kit/src/prop-types/extractProperties.test.ts
@@ -318,12 +318,14 @@ test('Should extract properties from selection', () => {
     optionsUrl: selection('Selection').optionsUrl('https://options.url'),
     searchable: selection('Selection').multiple().searchable(),
     selectable: selection('Selection').multiple().selectable(),
-    sorting: selection('Selection')
+    sortable: selection('Selection')
       .multiple()
       .searchable()
-      .sortBy('default', 'Original')
-      .sortBy('label', 'Name')
-      .sortBy('rightLabel', 'Price', true),
+      .sortable([
+        { label: 'Original', by: 'default' },
+        { label: 'Name', by: 'label' },
+        { label: 'Price', by: 'rightLabel' },
+      ]),
   };
 
   const { properties, strings } = extractProperties(propTypes);
@@ -339,7 +341,7 @@ test('Should extract properties from selection', () => {
     optionsUrl: 'Selection',
     searchable: 'Selection',
     selectable: 'Selection',
-    sorting: 'Selection',
+    sortable: 'Selection',
   });
   expect(properties).toEqual([
     {
@@ -412,17 +414,17 @@ test('Should extract properties from selection', () => {
     },
     {
       type: 'selection',
-      name: 'sorting',
+      name: 'sortable',
       multiple: true,
       searchable: true,
       optional: true,
       constraints: {},
       options: [],
-      sorting: {
-        default: { name: 'Original', isNumeric: false },
-        label: { name: 'Name', isNumeric: false },
-        rightLabel: { name: 'Price', isNumeric: true },
-      },
+      sortable: [
+        { label: 'Original', by: 'default' },
+        { label: 'Name', by: 'label' },
+        { label: 'Price', by: 'rightLabel' },
+      ],
     },
   ]);
 });

--- a/packages/raydiant-kit/src/prop-types/extractProperties.ts
+++ b/packages/raydiant-kit/src/prop-types/extractProperties.ts
@@ -39,6 +39,9 @@ export default function extractProperties(
     if (propType.type === 'selection') {
       prop.options = [];
       prop.multiple = propType.multiple;
+      prop.searchable = propType.searchable;
+      prop.selectable = propType.selectable;
+      prop.sorting = propType.sorting;
 
       if (propType.optionsUrl && propType.options.length > 0) {
         throw new Error(

--- a/packages/raydiant-kit/src/prop-types/extractProperties.ts
+++ b/packages/raydiant-kit/src/prop-types/extractProperties.ts
@@ -41,7 +41,7 @@ export default function extractProperties(
       prop.multiple = propType.multiple;
       prop.searchable = propType.searchable;
       prop.selectable = propType.selectable;
-      prop.sorting = propType.sorting;
+      prop.sortable = propType.sortable;
 
       if (propType.optionsUrl && propType.options.length > 0) {
         throw new Error(


### PR DESCRIPTION
## Description
- [(2) Toast: Add new dynamic multi-selects to Toast](https://trello.com/c/RLvp59Jg/2789-2-toast-add-new-dynamic-multi-selects-to-toast)

## Related raydiant-element PRs
- [[f] East - Add searching and bulk selection into MultiSelect and SelectionInput](https://github.com/mirainc/raydiant-elements/pull/403)
- [[f] East - Add rightLabel to MultiSelect](https://github.com/mirainc/raydiant-elements/pull/406)
- [[f] East - Add row-selected state to MultiSelect](https://github.com/mirainc/raydiant-elements/pull/407 )